### PR TITLE
DNSdataReader: add missing SGRID function prototype

### DIFF
--- a/DNSdata/src/DNSdataReader.h
+++ b/DNSdata/src/DNSdataReader.h
@@ -15,6 +15,7 @@ int DNS_call_sgrid(const char *command);
 int libsgrid_main(int argc, char **argv);
 extern int SGRID_memory_persists;
 int SGRID_grid_exists(void);
+void SGRID_free_everything(void);
 
 void SGRID_errorexits(char *file, int line, char *s, char *t);
 #define SGRID_errorexits(s,t) SGRID_errorexits(__FILE__, __LINE__, (s), (t))


### PR DESCRIPTION
The implicitly declared function `SGRID_free_everything` make gcc14 fail to compile the code:

```
COMPILING CactusSgrid/DNSdata/src/DNSdataReader.c
/Users/rhaas/Cactus/configs/sim/build/DNSdata/DNSdataReader.c: In function 'DNSdataReader':
/Users/rhaas/Cactus/configs/sim/build/DNSdata/DNSdataReader.c:492:27: error: implicit declaration of function 'SGRID_free_everything' [-Wimplicit-function-declaration]
  492 |   if(SGRID_grid_exists()) SGRID_free_everything();
      |
```